### PR TITLE
Update readme file name in gemspec

### DIFF
--- a/validate_url.gemspec
+++ b/validate_url.gemspec
@@ -13,10 +13,10 @@ Gem::Specification.new do |s|
   s.description = %q{Library for validating urls in Rails.}
   s.email = ["tanel.suurhans@perfectline.ee", "tarmo.lehtpuu@perfectline.ee"]
   s.extra_rdoc_files = [
-    "README.markdown"
+    "README.md"
   ]
   s.files = [
-    "README.markdown",
+    "README.md",
     "init.rb",
     "install.rb",
     "lib/validate_url.rb"


### PR DESCRIPTION
Since README.mdown is removed, the gemspec is invalid. While the gem works as expected, it produces scary errors when installing from GitHub.
