### PR TITLE
By default message is looked up by I18n

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ Jeweler::Tasks.new do |jewel|
   jewel.homepage        = 'http://github.com/perfectline/validates_url/tree/master'
   jewel.description     = 'Library for validating urls in Rails.'
   jewel.authors         = ["Tanel Suurhans", "Tarmo Lehtpuu"]
-  jewel.files           = FileList["lib/**/*.rb", "*.rb", "MIT-LICENCE", "README.markdown"]
+  jewel.files           = FileList["lib/**/*.rb", "lib/locale/*.yml", "*.rb", "MIT-LICENCE", "README.markdown"]
 
   jewel.add_dependency 'activemodel', '>= 3.0.0'
   jewel.add_dependency 'addressable'

--- a/lib/locale/en.yml
+++ b/lib/locale/en.yml
@@ -1,0 +1,4 @@
+en:
+  errors:
+    messages:
+      url: is not a valid URL

--- a/lib/validate_url.rb
+++ b/lib/validate_url.rb
@@ -1,5 +1,7 @@
 require 'addressable/uri'
 require 'active_model'
+require 'active_support/i18n'
+I18n.load_path << File.dirname(__FILE__) + '/locale/en.yml'
 
 module ActiveModel
   module Validations
@@ -7,7 +9,7 @@ module ActiveModel
 
       def initialize(options)
         options.reverse_merge!(:schemes => %w(http https))
-        options.reverse_merge!(:message => :invalid)
+        options.reverse_merge!(:message => :url)
         super(options)
       end
 

--- a/spec/resources/user_with_custom_message.rb
+++ b/spec/resources/user_with_custom_message.rb
@@ -1,0 +1,7 @@
+class UserWithCustomMessage
+  include ActiveModel::Validations
+
+  attr_accessor :homepage
+
+  validates :homepage, :url => {message: "wrong"}
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,10 +16,11 @@ ActiveRecord::Base.establish_connection(
 
 require File.join(File.dirname(__FILE__), '..', 'init')
 
-autoload :User,                 'resources/user'
-autoload :UserWithNil,          'resources/user_with_nil'
-autoload :UserWithBlank,        'resources/user_with_blank'
-autoload :UserWithLegacySyntax, 'resources/user_with_legacy_syntax'
-autoload :UserWithAr,           'resources/user_with_ar'
-autoload :UserWithArLegacy,     'resources/user_with_ar_legacy'
-autoload :UserWithCustomScheme, 'resources/user_with_custom_scheme'
+autoload :User,                  'resources/user'
+autoload :UserWithNil,           'resources/user_with_nil'
+autoload :UserWithBlank,         'resources/user_with_blank'
+autoload :UserWithLegacySyntax,  'resources/user_with_legacy_syntax'
+autoload :UserWithAr,            'resources/user_with_ar'
+autoload :UserWithArLegacy,      'resources/user_with_ar_legacy'
+autoload :UserWithCustomScheme,  'resources/user_with_custom_scheme'
+autoload :UserWithCustomMessage, 'resources/user_with_custom_message'

--- a/spec/validate_url_spec.rb
+++ b/spec/validate_url_spec.rb
@@ -60,6 +60,12 @@ describe "URL validation" do
       @user.homepage = "http://foo_bar.com"
       @user.should be_valid
     end
+
+    it "should return a default error message" do
+      @user.homepage = "invalid"
+      @user.valid?
+      @user.errors[:homepage].should == ["is not a valid URL"]
+    end
   end
 
   context "with allow nil" do
@@ -175,6 +181,18 @@ describe "URL validation" do
     it "should allow alternative URI schemes" do
       @user.homepage = "ftp://ftp.example.com"
       @user.should be_valid
+    end
+  end
+
+  context "with custom message" do
+    before do
+      @user = UserWithCustomMessage.new
+    end
+
+    it "should use custom message" do
+      @user.homepage = "invalid"
+      @user.valid?
+      @user.errors[:homepage].should == ["wrong"]
     end
   end
 end

--- a/validate_url.gemspec
+++ b/validate_url.gemspec
@@ -21,7 +21,8 @@ Gem::Specification.new do |s|
   s.files = [
     "init.rb",
     "install.rb",
-    "lib/validate_url.rb"
+    "lib/validate_url.rb",
+    "lib/locale/en.yml"
   ]
   s.homepage = "http://github.com/perfectline/validates_url/tree/master"
   s.rubygems_version = "2.2.2"


### PR DESCRIPTION
ActiveRecord has an elaborate system of looking up translactions for error messages from default to more specific ones. http://guides.rubyonrails.org/i18n.html#basic-lookup-scopes-and-nested-keys

```
  activerecord:
    errors:
      messages:
        invalid: "Can you take another look here?"
      models:
        lead_form:
          attributes:
            redirect_url:
              invalid: "Ooops! This thingy doesn't look like a proper URL"
```

Default message `:invalid` makes ActiveRecord look up translations while still allowing message to be overridden in the model.
