### PR TITLE
Allow option to require protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ class Pony < ActiveRecord::Base
 
   # with allow_blank
   validates :homepage, :url => {:allow_blank => true}
+
+  # with require_protocol, needs to include a protocol:// prefix
+  validates :homepage, :url => {:require_protocol => true}
 end
 ```
 

--- a/lib/validate_url.rb
+++ b/lib/validate_url.rb
@@ -20,6 +20,11 @@ module ActiveModel
           unless uri && schemes.include?(uri.scheme)
             record.errors.add(attribute, options.fetch(:message), :value => value)
           end
+          if options[:require_protocol]
+            raise Addressable::URI::InvalidURIError unless schemes.any? {
+              |scheme| value.starts_with?("#{scheme}://")
+            }
+          end
         rescue Addressable::URI::InvalidURIError
           record.errors.add(attribute, options.fetch(:message), :value => value)
         end
@@ -39,6 +44,7 @@ module ActiveModel
       # * <tt>:message</tt> - A custom error message (default is: "is not a valid URL").
       # * <tt>:allow_nil</tt> - If set to true, skips this validation if the attribute is +nil+ (default is +false+).
       # * <tt>:allow_blank</tt> - If set to true, skips this validation if the attribute is blank (default is +false+).
+      # * <tt>:require_protocol</tt> - If set to true, invalidates url if it is missing protocol (default is +false+).
       # * <tt>:schemes</tt> - Array of URI schemes to validate against. (default is +['http', 'https']+)
 
       def validates_url(*attr_names)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,11 +16,12 @@ ActiveRecord::Base.establish_connection(
 
 require File.join(File.dirname(__FILE__), '..', 'init')
 
-autoload :User,                  'resources/user'
-autoload :UserWithNil,           'resources/user_with_nil'
-autoload :UserWithBlank,         'resources/user_with_blank'
-autoload :UserWithLegacySyntax,  'resources/user_with_legacy_syntax'
-autoload :UserWithAr,            'resources/user_with_ar'
-autoload :UserWithArLegacy,      'resources/user_with_ar_legacy'
-autoload :UserWithCustomScheme,  'resources/user_with_custom_scheme'
-autoload :UserWithCustomMessage, 'resources/user_with_custom_message'
+autoload :User,                        'resources/user'
+autoload :UserWithNil,                 'resources/user_with_nil'
+autoload :UserWithBlank,               'resources/user_with_blank'
+autoload :UserWithLegacySyntax,        'resources/user_with_legacy_syntax'
+autoload :UserWithAr,                  'resources/user_with_ar'
+autoload :UserWithArLegacy,            'resources/user_with_ar_legacy'
+autoload :UserWithCustomScheme,        'resources/user_with_custom_scheme'
+autoload :UserWithCustomMessage,       'resources/user_with_custom_message'
+autoload :UserWithProtocolRequirement, 'resources/user_with_protocol_requirement'

--- a/spec/validate_url_spec.rb
+++ b/spec/validate_url_spec.rb
@@ -94,6 +94,32 @@ describe "URL validation" do
     end
   end
 
+  context "with require protocol" do
+    before do
+      @user = UserWithRequireProtocol.new
+    end
+
+    it "should allow nil as url" do
+      @user.homepage = nil
+      @user.should be_valid
+    end
+
+    it "should allow blank as url" do
+      @user.homepage = ""
+      @user.should be_valid
+    end
+
+    it "should allow a valid url" do
+      @user.homepage = "http://www.example.com"
+      @user.should be_valid
+    end
+
+    it "should not allow a url without a protocol" do
+      @user.homepage = "www.example.com"
+      @user.should_not be_valid
+    end
+  end
+
   context "with allow blank" do
     before do
       @user = UserWithBlank.new


### PR DESCRIPTION
This raises a validate message if the option require_protocol is enabled, and http:// for example is missed from the URL
