### PR TITLE
Add posibility to change error placement

### DIFF
--- a/lib/validate_url.rb
+++ b/lib/validate_url.rb
@@ -10,18 +10,20 @@ module ActiveModel
       def initialize(options)
         options.reverse_merge!(:schemes => %w(http https))
         options.reverse_merge!(:message => :url)
+        options.reverse_merge!(:add_to => nil)
         super(options)
       end
 
       def validate_each(record, attribute, value)
         schemes = [*options.fetch(:schemes)].map(&:to_s)
+        add_to = options.fetch(:add_to)
         begin
           uri = Addressable::URI.parse(value)
           unless uri && uri.host && schemes.include?(uri.scheme)
-            record.errors.add(attribute, options.fetch(:message), :value => value)
+            record.errors.add(add_to || attribute, options.fetch(:message), :value => value)
           end
         rescue Addressable::URI::InvalidURIError
-          record.errors.add(attribute, options.fetch(:message), :value => value)
+          record.errors.add(add_to || attribute, options.fetch(:message), :value => value)
         end
       end
     end

--- a/spec/resources/user_with_custom_add_to.rb
+++ b/spec/resources/user_with_custom_add_to.rb
@@ -1,0 +1,7 @@
+class UserWithCustomAddTo
+  include ActiveModel::Validations
+
+  attr_accessor :homepage
+
+  validates :homepage, :url => {add_to: :base}
+end

--- a/spec/validate_url_spec.rb
+++ b/spec/validate_url_spec.rb
@@ -200,4 +200,16 @@ describe "URL validation" do
       @user.errors[:homepage].should == ["wrong"]
     end
   end
+
+  context "with custom add_to" do
+    before do
+      @user = UserWithCustomAddTo.new
+    end
+
+    it "should use custom add_to" do
+      @user.homepage = "invalid"
+      @user.valid?
+      @user.errors[:base].should == ["wrong"]
+    end
+  end
 end


### PR DESCRIPTION
Sometimes the field name does not match the record and thus th errors is not placed anywhere, i added the posibility to override this.
Note that is also common to add errors to :base so this works in that case too.
