### PR TITLE
:value in custom error message not populated

### DIFF
--- a/lib/validate_url.rb
+++ b/lib/validate_url.rb
@@ -20,10 +20,10 @@ module ActiveModel
         begin
           uri = Addressable::URI.parse(value)
           unless uri && uri.host && schemes.include?(uri.scheme) && (!options.fetch(:no_local) || uri.host.include?('.'))
-            record.errors.add(attribute, options.fetch(:message), :value => value)
+            record.errors.add(attribute, options.fetch(:message) % {:value => value})
           end
         rescue Addressable::URI::InvalidURIError
-          record.errors.add(attribute, options.fetch(:message), :value => value)
+          record.errors.add(attribute, options.fetch(:message) % {:value => value})
         end
       end
     end


### PR DESCRIPTION
When adding custom message, value is not populated
validates :myurl, :url => { message: "%{value} is not valid" }