### PR TITLE
Use correct default error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ end
 
 ### I18n
 
-The default error message `is not valid url`.
+The default error message `is not a valid URL`.
 You can pass the `:message => "my custom error"` option to your validation to define your own, custom message.
 
 


### PR DESCRIPTION
GitHub has added a blank line of whitespace on the end there for whatever reason.