### PR TITLE
Stricter URI validation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,6 @@ Jeweler::Tasks.new do |jewel|
   jewel.files           = FileList["lib/**/*.rb", "lib/locale/*.yml", "*.rb", "MIT-LICENCE", "README.markdown"]
 
   jewel.add_dependency 'activemodel', '>= 3.0.0'
-  jewel.add_dependency 'addressable'
   jewel.add_development_dependency 'rspec'
   jewel.add_development_dependency 'diff-lcs', '>= 1.1.2'
 end

--- a/lib/validate_url.rb
+++ b/lib/validate_url.rb
@@ -1,4 +1,3 @@
-require 'addressable/uri'
 require 'active_model'
 require 'active_support/i18n'
 I18n.load_path += Dir[File.dirname(__FILE__) + "/locale/*.yml"]
@@ -19,11 +18,11 @@ module ActiveModel
       def validate_each(record, attribute, value)
         schemes = [*options.fetch(:schemes)].map(&:to_s)
         begin
-          uri = Addressable::URI.parse(value)
+          uri = URI.parse(value)
           unless uri && uri.host && schemes.include?(uri.scheme) && (!options.fetch(:no_local) || uri.host.include?('.'))
             record.errors.add(attribute, :url, filtered_options(value))
           end
-        rescue Addressable::URI::InvalidURIError
+        rescue URI::InvalidURIError
           record.errors.add(attribute, :url, filtered_options(value))
         end
       end

--- a/validate_url.gemspec
+++ b/validate_url.gemspec
@@ -39,18 +39,15 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<activemodel>, [">= 3.0.0"])
-      s.add_runtime_dependency(%q<addressable>, [">= 0"])
       s.add_development_dependency(%q<rspec>, [">= 3.0.0"])
       s.add_development_dependency(%q<diff-lcs>, [">= 1.1.2"])
     else
       s.add_dependency(%q<activemodel>, [">= 3.0.0"])
-      s.add_dependency(%q<addressable>, [">= 0"])
       s.add_dependency(%q<rspec>, [">= 0"])
       s.add_dependency(%q<diff-lcs>, [">= 1.1.2"])
     end
   else
     s.add_dependency(%q<activemodel>, [">= 3.0.0"])
-    s.add_dependency(%q<addressable>, [">= 0"])
     s.add_dependency(%q<rspec>, [">= 0"])
     s.add_dependency(%q<diff-lcs>, [">= 1.1.2"])
   end


### PR DESCRIPTION
Use Ruby's URI class, since it validates strictly instead of the more lax behaviours of Addressable.

Closes #34
Closes #55