### PR TITLE
Add info about schemes in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ class Pony < ActiveRecord::Base
 
   # without local hostnames
   validates :homepage, :url => {:no_local => true}
+
+  # with custom schemes
+  validates :homepage, :url => {:schemes => ['https']}
 end
 ```
 


### PR DESCRIPTION
I noticed that there is no mention of the `scheme` option in the README file.
I think it could be useful to add this change. Please let me know WDYT.