### PR TITLE
Adds RSpec Matcher

### DIFF
--- a/lib/rspec_matcher.rb
+++ b/lib/rspec_matcher.rb
@@ -1,0 +1,12 @@
+RSpec::Matchers.define :validate_url_of do |attribute|
+  match do
+    actual = subject.is_a?(Class) ? subject.new : subject
+    actual.send(:"#{attribute}=", "htp://invalidurl")
+    expect(actual).to be_invalid
+    @expected_message ||= I18n.t("errors.messages.url")
+    expect(actual.errors.messages[attribute.to_sym]).to include(@expected_message)
+  end
+  chain :with_message do |message|
+    @expected_message = message
+  end
+end

--- a/spec/resources/user_with_custom_scheme.rb
+++ b/spec/resources/user_with_custom_scheme.rb
@@ -3,5 +3,5 @@ class UserWithCustomScheme
 
   attr_accessor :homepage
 
-  validates :homepage, url { schemes: ['ftp'] }
+  validates :homepage, url: { schemes: ['ftp'] }
 end

--- a/spec/rspec_matcher_spec.rb
+++ b/spec/rspec_matcher_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+
+if defined?(ActiveModel)
+  require_relative "../lib/rspec_matcher"
+
+  describe "RSpec matcher" do
+    subject { User }
+
+    it "should ensure that attributes are validated" do
+      should validate_url_of(:homepage)
+    end
+  end
+end


### PR DESCRIPTION
This PR addresses a need raised in  #56 and adds an RSpec matcher (`validate_url_of`) ensuring that a given attribute is having its format validated.  Inspired very much by the [`validates_email_format_of` matcher](https://github.com/validates-email-format-of/validates_email_format_of/blob/master/lib/validates_email_format_of/rspec_matcher.rb).

Additionally, this PR fixes a simple typo in [`UserWithCustomScheme`](https://github.com/perfectline/validates_url/blob/master/spec/resources/user_with_custom_scheme.rb#L6) that was causing the suite to fail.