### PR TITLE
Fix no_local regression when host nil

### DIFF
--- a/lib/validate_url.rb
+++ b/lib/validate_url.rb
@@ -22,7 +22,7 @@ module ActiveModel
         begin
           uri = URI.parse(value)
           validate_suffix = !options.fetch(:public_suffix) || (uri && uri.host && PublicSuffix.valid?(uri.host, :default_rule => nil))
-          validate_no_local = !options.fetch(:no_local) || uri.host.include?('.')
+          validate_no_local = !options.fetch(:no_local) || (uri && uri.host && uri.host.include?('.'))
           unless uri && uri.host && schemes.include?(uri.scheme) && validate_no_local && validate_suffix
             record.errors.add(attribute, options.fetch(:message), value: value)
           end

--- a/lib/validate_url.rb
+++ b/lib/validate_url.rb
@@ -21,9 +21,14 @@ module ActiveModel
         schemes = [*options.fetch(:schemes)].map(&:to_s)
         begin
           uri = URI.parse(value)
-          validate_suffix = !options.fetch(:public_suffix) || (uri && uri.host && PublicSuffix.valid?(uri.host, :default_rule => nil))
-          validate_no_local = !options.fetch(:no_local) || (uri && uri.host && uri.host.include?('.'))
-          unless uri && uri.host && schemes.include?(uri.scheme) && validate_no_local && validate_suffix
+          host = uri && uri.host
+          scheme = uri && uri.scheme
+
+          valid_suffix = !options.fetch(:public_suffix) || (host && PublicSuffix.valid?(host, :default_rule => nil))
+          valid_no_local = !options.fetch(:no_local) || (host && host.include?('.'))
+          valid_scheme = host && scheme && schemes.include?(scheme)
+
+          unless valid_scheme && valid_no_local && valid_suffix
             record.errors.add(attribute, options.fetch(:message), value: value)
           end
         rescue URI::InvalidURIError

--- a/spec/validate_url_spec.rb
+++ b/spec/validate_url_spec.rb
@@ -161,6 +161,11 @@ describe "URL validation" do
       @user.homepage = "http://http://example.com"
       expect(@user).not_to be_valid
     end
+
+    it "does not allow an url without scheme" do
+      @user.homepage = "www.example.com"
+      expect(@user).not_to be_valid
+    end
   end
 
   context "with public_suffix" do


### PR DESCRIPTION
This fixes a regression introduced by #35 when host is nil for no_local validation.

I benefited from that to add a regression test and refactor slightly the validation code to be a bit dryer.