### PR TITLE
Add Gemfile to simplify dev/test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,106 @@
+PATH
+  remote: .
+  specs:
+    validate_url (1.0.2)
+      activemodel (>= 3.0.0)
+      public_suffix (>= 2.0.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (5.2.2)
+      activesupport (= 5.2.2)
+    activerecord (5.2.2)
+      activemodel (= 5.2.2)
+      activesupport (= 5.2.2)
+      arel (>= 9.0)
+    activesupport (5.2.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    addressable (2.4.0)
+    arel (9.0.0)
+    builder (3.2.3)
+    concurrent-ruby (1.1.4)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
+    diff-lcs (1.3)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
+    git (1.5.0)
+    github_api (0.16.0)
+      addressable (~> 2.4.0)
+      descendants_tracker (~> 0.0.4)
+      faraday (~> 0.8, < 0.10)
+      hashie (>= 3.4)
+      mime-types (>= 1.16, < 3.0)
+      oauth2 (~> 1.0)
+    hashie (3.6.0)
+    highline (2.0.0)
+    i18n (1.5.2)
+      concurrent-ruby (~> 1.0)
+    jeweler (2.3.9)
+      builder
+      bundler
+      git (>= 1.2.5)
+      github_api (~> 0.16.0)
+      highline (>= 1.6.15)
+      nokogiri (>= 1.5.10)
+      psych
+      rake
+      rdoc
+      semver2
+    jwt (2.1.0)
+    mime-types (2.99.3)
+    mini_portile2 (2.4.0)
+    minitest (5.11.3)
+    multi_json (1.13.1)
+    multi_xml (0.6.0)
+    multipart-post (2.0.0)
+    nokogiri (1.10.1)
+      mini_portile2 (~> 2.4.0)
+    oauth2 (1.4.1)
+      faraday (>= 0.8, < 0.16.0)
+      jwt (>= 1.0, < 3.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 3)
+    psych (3.1.0)
+    public_suffix (3.0.3)
+    rack (2.0.6)
+    rake (12.3.1)
+    rdoc (6.1.1)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
+    semver2 (3.4.2)
+    sqlite3 (1.3.13)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activerecord
+  diff-lcs (>= 1.1.2)
+  jeweler
+  rake
+  rspec (>= 3.0.0)
+  sqlite3
+  validate_url!
+
+BUNDLED WITH
+   1.16.2

--- a/validate_url.gemspec
+++ b/validate_url.gemspec
@@ -34,25 +34,15 @@ Gem::Specification.new do |s|
   s.rubygems_version = "2.4.5"
   s.summary = "Library for validating urls in Rails."
 
-  if s.respond_to? :specification_version then
-    s.specification_version = 4
+  s.specification_version = 4
 
-    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<activemodel>, [">= 3.0.0"])
-      s.add_runtime_dependency(%q<public_suffix>, [">= 2.0.0"])
-      s.add_development_dependency(%q<rspec>, [">= 3.0.0"])
-      s.add_development_dependency(%q<diff-lcs>, [">= 1.1.2"])
-    else
-      s.add_dependency(%q<activemodel>, [">= 3.0.0"])
-      s.add_dependency(%q<public_suffix>, [">= 2.0.0"])
-      s.add_dependency(%q<rspec>, [">= 0"])
-      s.add_dependency(%q<diff-lcs>, [">= 1.1.2"])
-    end
-  else
-    s.add_dependency(%q<activemodel>, [">= 3.0.0"])
-    s.add_dependency(%q<public_suffix>, [">= 2.0.0"])
-    s.add_dependency(%q<rspec>, [">= 0"])
-    s.add_dependency(%q<diff-lcs>, [">= 1.1.2"])
-  end
+  s.add_runtime_dependency(%q<activemodel>, [">= 3.0.0"])
+  s.add_runtime_dependency(%q<public_suffix>, [">= 2.0.0"])
+  s.add_development_dependency(%q<rspec>, [">= 3.0.0"])
+  s.add_development_dependency(%q<diff-lcs>, [">= 1.1.2"])
+  s.add_development_dependency(%q<rake>, [">= 0"])
+  s.add_development_dependency(%q<jeweler>, [">= 0"])
+  s.add_development_dependency(%q<sqlite3>, [">= 0"])
+  s.add_development_dependency(%q<activerecord>, [">= 0"])
 end
 


### PR DESCRIPTION
The main goal of this PR is to simplify development/testing by adding a Gemfile to the project.

```
bundle install # install dependencies
bundle exec rake # run tests
```

This adds missing development dependencies to gemspec and drops support for old rubygems versions to avoid bloating runtime dependencies (otherwise we would be bloating runtime dependencies for those).