### PR TITLE
Fix circular dependency in new version 1.0.5

### DIFF
--- a/validate_url.gemspec
+++ b/validate_url.gemspec
@@ -44,7 +44,6 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<validate_url>, [">= 0"])
       s.add_development_dependency(%q<jeweler>, [">= 0"])
       s.add_development_dependency(%q<sqlite3>, [">= 0"])
       s.add_development_dependency(%q<activerecord>, [">= 0"])
@@ -53,7 +52,6 @@ Gem::Specification.new do |s|
       s.add_runtime_dependency(%q<activemodel>, [">= 3.0.0"])
       s.add_runtime_dependency(%q<public_suffix>, [">= 0"])
     else
-      s.add_dependency(%q<validate_url>, [">= 0"])
       s.add_dependency(%q<jeweler>, [">= 0"])
       s.add_dependency(%q<sqlite3>, [">= 0"])
       s.add_dependency(%q<activerecord>, [">= 0"])
@@ -63,7 +61,6 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<public_suffix>, [">= 0"])
     end
   else
-    s.add_dependency(%q<validate_url>, [">= 0"])
     s.add_dependency(%q<jeweler>, [">= 0"])
     s.add_dependency(%q<sqlite3>, [">= 0"])
     s.add_dependency(%q<activerecord>, [">= 0"])


### PR DESCRIPTION
```
Updating validate_url
ERROR:  While executing gem ... (Gem::Resolver::Molinillo::CircularDependencyError)
    There is a circular dependency between validate_url and validate_url
```