### PR TITLE
Fixed a failing spec when validation nil

### DIFF
--- a/lib/validate_url.rb
+++ b/lib/validate_url.rb
@@ -20,7 +20,8 @@ module ActiveModel
       def validate_each(record, attribute, value)
         schemes = [*options.fetch(:schemes)].map(&:to_s)
         begin
-          uri = URI.parse(URI.escape(value))
+          escaped_uri = value ? URI.escape(value) : nil
+          uri = URI.parse(escaped_uri)
           host = uri && uri.host
           scheme = uri && uri.scheme
 


### PR DESCRIPTION
Fix for #76 - We now only escape the value if it's not nil, meaning all specs now pass again.