### PR TITLE
RSpec: disable_monkey_patching + let! usage

### DIFF
--- a/spec/rspec_matcher_spec.rb
+++ b/spec/rspec_matcher_spec.rb
@@ -1,11 +1,11 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
-if defined?(ActiveModel)
-  describe "RSpec matcher" do
-    subject { User }
+RSpec.describe "RSpec matcher", if: defined?(ActiveModel) do
+  subject { User }
 
-    it "should ensure that attributes are validated" do
-      should validate_url_of(:homepage)
-    end
+  it "ensures that attributes are validated" do
+    is_expected.to validate_url_of(:homepage)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift(File.dirname(__FILE__) + '/../lib')
 $LOAD_PATH.unshift(File.dirname(__FILE__) + '/resources')
 $LOAD_PATH.unshift(File.dirname(__FILE__))
@@ -11,8 +13,8 @@ require 'validate_url/rspec_matcher'
 
 ActiveRecord::Migration.verbose = false
 ActiveRecord::Base.establish_connection(
-    "adapter"   => "sqlite3",
-    "database"  => ":memory:"
+    "adapter" => "sqlite3",
+    "database" => ":memory:"
 )
 
 require File.join(File.dirname(__FILE__), '..', 'init')
@@ -30,3 +32,5 @@ autoload :UserWithPublicSuffix,           'resources/user_with_public_suffix'
 autoload :UserWithAcceptArray,            'resources/user_with_accept_array'
 autoload :UserWithAcceptArrayWithNil,     'resources/user_with_accept_array_with_nil'
 autoload :UserWithAcceptArrayWithBlank,   'resources/user_with_accept_array_with_blank'
+
+RSpec.configure(&:disable_monkey_patching!)

--- a/spec/validate_url_spec.rb
+++ b/spec/validate_url_spec.rb
@@ -1,9 +1,8 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
 require 'spec_helper'
 
-describe "URL validation" do
-
+RSpec.describe 'URL validation' do
   before(:all) do
     ActiveRecord::Schema.define(version: 1) do
       create_table :users, force: true do |t|
@@ -16,325 +15,334 @@ describe "URL validation" do
     ActiveRecord::Base.connection.drop_table(:users)
   end
 
-  context "with regular validator" do
-    before do
-      @user = User.new
+  context 'with regular validator' do
+    let!(:user) { User.new }
+
+    it 'does not allow nil as url' do
+      user.homepage = nil
+
+      expect(user).not_to be_valid
     end
 
-    it "does not allow nil as url" do
-      @user.homepage = nil
-      expect(@user).not_to be_valid
+    it 'does not allow blank as url' do
+      user.homepage = ''
+
+      expect(user).not_to be_valid
     end
 
-    it "does not allow blank as url" do
-      @user.homepage = ""
-      expect(@user).not_to be_valid
+    it 'does not allow an url without scheme' do
+      user.homepage = 'www.example.com'
+
+      expect(user).not_to be_valid
     end
 
-    it "does not allow an url without scheme" do
-      @user.homepage = "www.example.com"
-      expect(@user).not_to be_valid
+    it 'allows an url with http' do
+      user.homepage = 'http://localhost'
+
+      expect(user).to be_valid
     end
 
-    it "allows an url with http" do
-      @user.homepage = "http://localhost"
-      expect(@user).to be_valid
+    it 'allows an url with https' do
+      user.homepage = 'https://localhost'
+
+      expect(user).to be_valid
     end
 
-    it "allows an url with https" do
-      @user.homepage = "https://localhost"
-      expect(@user).to be_valid
+    it 'does not allow a url with an invalid scheme' do
+      user.homepage = 'ftp://localhost'
+
+      expect(user).not_to be_valid
     end
 
-    it "does not allow a url with an invalid scheme" do
-      @user.homepage = "ftp://localhost"
-      expect(@user).not_to be_valid
+    it 'does not allow a url with only a scheme' do
+      user.homepage = 'http://'
+
+      expect(user).not_to be_valid
     end
 
-    it "does not allow a url with only a scheme" do
-      @user.homepage = "http://"
-      expect(@user).not_to be_valid
+    it 'does not allow a url without a host' do
+      user.homepage = 'http:/'
+
+      expect(user).not_to be_valid
     end
 
-    it "does not allow a url without a host" do
-      @user.homepage = "http:/"
-      expect(@user).not_to be_valid
-    end
+    it 'allows a url with an underscore' do
+      user.homepage = 'http://foo_bar.com'
 
-    it "allows a url with an underscore" do
-      @user.homepage = "http://foo_bar.com"
-      expect(@user).to be_valid
+      expect(user).to be_valid
     end
 
     it "does not allow a url with a space in the hostname" do
-      @user.homepage = "http://foo bar.com"
-      expect(@user).not_to be_valid
+      user.homepage = "http://foo bar.com"
+      expect(user).not_to be_valid
     end
 
     it "does not allow a url with a space in the querystring" do
-      @user.homepage = "http://example.com/some/? doodads=ok"
-      expect(@user).not_to be_valid
+      user.homepage = "http://example.com/some/? doodads=ok"
+      expect(user).not_to be_valid
     end
 
     it "returns a default error message" do
-      @user.homepage = "invalid"
-      @user.valid?
-      expect(@user.errors[:homepage]).to eq(["is not a valid URL"])
+      user.homepage = "invalid"
+      user.valid?
+      expect(user.errors[:homepage]).to eq(["is not a valid URL"])
     end
 
     it "does not allow an array of urls" do
-      @user.homepage = ["https://foo.com", "https://bar.com"]
-      expect(@user).not_to be_valid
+      user.homepage = ["https://foo.com", "https://bar.com"]
+      expect(user).not_to be_valid
     end
 
     context "when locale is turkish" do
       it "returns a Turkish default error message" do
         I18n.locale = :tr
-        @user.homepage = "Black Tea"
-        @user.valid?
-        expect(@user.errors[:homepage]).to eq(["Geçerli bir URL değil"])
+        user.homepage = 'Black Tea'
+        user.valid?
+
+        expect(user.errors[:homepage]).to eq(['Geçerli bir URL değil'])
       end
     end
-    context "when locale is Japanese" do
-      it "returns a Japanese default error message" do
+
+    context 'when locale is Japanese' do
+      it 'returns a Japanese default error message' do
         I18n.locale = :ja
-        @user.homepage = "黒麦茶"
-        @user.valid?
-        expect(@user.errors[:homepage]).to eq(["は不正なURLです"])
+        user.homepage = '黒麦茶'
+        user.valid?
+        expect(user.errors[:homepage]).to eq(['は不正なURLです'])
       end
     end
   end
 
-  context "with allow nil" do
-    before do
-      @user = UserWithNil.new
+  context 'with allow nil' do
+    let!(:user) { UserWithNil.new }
+
+    it 'allows nil as url' do
+      user.homepage = nil
+
+      expect(user).to be_valid
     end
 
-    it "allows nil as url" do
-      @user.homepage = nil
-      expect(@user).to be_valid
+    it 'does not allow blank as url' do
+      user.homepage = ''
+
+      expect(user).not_to be_valid
     end
 
-    it "does not allow blank as url" do
-      @user.homepage = ""
-      expect(@user).not_to be_valid
+    it 'allows a valid url' do
+      user.homepage = 'http://www.example.com'
+
+      expect(user).to be_valid
     end
 
-    it "allows a valid url" do
-      @user.homepage = "http://www.example.com"
-      expect(@user).to be_valid
-    end
+    it 'allows a url with an underscore' do
+      user.homepage = 'http://foo_bar.com'
 
-    it "allows a url with an underscore" do
-      @user.homepage = "http://foo_bar.com"
-      expect(@user).to be_valid
-    end
-  end
-
-  context "with allow blank" do
-    before do
-      @user = UserWithBlank.new
-    end
-
-    it "allows nil as url" do
-      @user.homepage = nil
-      expect(@user).to be_valid
-    end
-
-    it "allows blank as url" do
-      @user.homepage = ""
-      expect(@user).to be_valid
-    end
-
-    it "allows a valid url" do
-      @user.homepage = "http://www.example.com"
-      expect(@user).to be_valid
-    end
-
-    it "allows a url with an underscore" do
-      @user.homepage = "http://foo_bar.com"
-      expect(@user).to be_valid
+      expect(user).to be_valid
     end
   end
 
-  context "with no_local" do
-    before do
-      @user = UserWithNoLocal.new
+  context 'with allow blank' do
+    let!(:user) { UserWithBlank.new }
+
+    it 'allows nil as url' do
+      user.homepage = nil
+
+      expect(user).to be_valid
     end
 
-    it "allows a valid internet url" do
-      @user.homepage = "http://www.example.com"
-      expect(@user).to be_valid
+    it 'allows blank as url' do
+      user.homepage = ''
+
+      expect(user).to be_valid
     end
 
-    it "does not allow a local hostname" do
-      @user.homepage = "http://localhost"
-      expect(@user).not_to be_valid
+    it 'allows a valid url' do
+      user.homepage = 'http://www.example.com'
+
+      expect(user).to be_valid
     end
 
-    it "does not allow weird urls that get interpreted as local hostnames" do
-      @user.homepage = "http://http://example.com"
-      expect(@user).not_to be_valid
-    end
+    it 'allows a url with an underscore' do
+      user.homepage = 'http://foo_bar.com'
 
-    it "does not allow an url without scheme" do
-      @user.homepage = "www.example.com"
-      expect(@user).not_to be_valid
+      expect(user).to be_valid
     end
   end
 
-  context "with public_suffix" do
-    before do
-      @user = UserWithPublicSuffix.new
+  context 'with no_local' do
+    let!(:user) { UserWithNoLocal.new }
+
+    it 'allows a valid internet url' do
+      user.homepage = 'http://www.example.com'
+
+      expect(user).to be_valid
     end
 
-    it "should allow a valid public suffix" do
-      @user.homepage = "http://www.example.com"
-      expect(@user).to be_valid
+    it 'does not allow a local hostname' do
+      user.homepage = 'http://localhost'
+
+      expect(user).not_to be_valid
     end
 
-    it "should not allow a local hostname" do
-      @user.homepage = "http://localhost"
-      expect(@user).not_to be_valid
+    it 'does not allow weird urls that get interpreted as local hostnames' do
+      user.homepage = 'http://http://example.com'
+
+      expect(user).not_to be_valid
     end
 
-    it "should not allow non public hosts suffixes" do
-      @user.homepage = "http://example.not_a_valid_tld"
-      expect(@user).not_to be_valid
+    it 'does not allow an url without scheme' do
+      user.homepage = 'www.example.com'
+
+      expect(user).not_to be_valid
+    end
+  end
+
+  context 'with public_suffix' do
+    let!(:user) { UserWithPublicSuffix.new }
+
+    it 'allows a valid public suffix' do
+      user.homepage = 'http://www.example.com'
+
+      expect(user).to be_valid
+    end
+
+    it 'does not allow a local hostname' do
+      user.homepage = 'http://localhost'
+
+      expect(user).not_to be_valid
+    end
+
+    it 'does not allow non public hosts suffixes' do
+      user.homepage = 'http://example.not_a_valid_tld'
+
+      expect(user).not_to be_valid
     end
 
     it "should not allow an array with non public hosts suffixes" do
-      @user.homepage = ["http://www.example.com", "http://example.not_a_valid_tld"]
-      expect(@user).not_to be_valid
+      user.homepage = ["http://www.example.com", "http://example.not_a_valid_tld"]
+      expect(user).not_to be_valid
     end
   end
 
   context "with accept array" do
-    before do
-      @user = UserWithAcceptArray.new
-    end
+    let!(:user) { UserWithAcceptArray.new }
 
     it "allows an array of urls" do
-      @user.homepage = ["https://foo.com", "https://bar.com"]
-      expect(@user).to be_valid
+      user.homepage = ["https://foo.com", "https://bar.com"]
+      expect(user).to be_valid
     end
 
     it "returns errors on an array of urls if one is invalid" do
-      @user.homepage = ["https://foo.com", "https://foo bar.com"]
-      expect(@user).not_to be_valid
+      user.homepage = ["https://foo.com", "https://foo bar.com"]
+      expect(user).not_to be_valid
     end
 
     it "returns errors on an array of urls if one is nil" do
-      @user.homepage = ["https://foo.com", nil]
-      expect(@user).not_to be_valid
+      user.homepage = ["https://foo.com", nil]
+      expect(user).not_to be_valid
     end
 
     it "returns errors on an array of urls if one is empty" do
-      @user.homepage = ["https://foo.com", ""]
-      expect(@user).not_to be_valid
+      user.homepage = ["https://foo.com", ""]
+      expect(user).not_to be_valid
     end
 
     it "allows a normal string to be validated without an array" do
-      @user.homepage = "https://www.example.com"
-      expect(@user).to be_valid
+      user.homepage = "https://www.example.com"
+      expect(user).to be_valid
     end
   end
 
   context "with accept array with nil" do
-    before do
-      @user = UserWithAcceptArrayWithNil.new
-    end
+    let!(:user) { UserWithAcceptArrayWithNil.new }
 
     it "allows an array of urls with a nil" do
-      @user.homepage = ["https://foo.com", nil]
-      expect(@user).to be_valid
+      user.homepage = ["https://foo.com", nil]
+      expect(user).to be_valid
     end
   end
 
   context "with accept array with blank" do
-    before do
-      @user = UserWithAcceptArrayWithBlank.new
-    end
+    let!(:user) { UserWithAcceptArrayWithBlank.new }
 
     it "allows an array of urls with a blank" do
-      @user.homepage = ["https://foo.com", ""]
-      expect(@user).to be_valid
+      user.homepage = ["https://foo.com", ""]
+      expect(user).to be_valid
     end
   end
 
-  context "with legacy syntax" do
-    before do
-      @user = UserWithLegacySyntax.new
+  context 'with legacy syntax' do
+    let!(:user) { UserWithLegacySyntax.new }
+
+    it 'allows nil as url' do
+      user.homepage = nil
+
+      expect(user).to be_valid
     end
 
-    it "allows nil as url" do
-      @user.homepage = nil
-      expect(@user).to be_valid
+    it 'allows blank as url' do
+      user.homepage = ''
+
+      expect(user).to be_valid
     end
 
-    it "allows blank as url" do
-      @user.homepage = ""
-      expect(@user).to be_valid
+    it 'allows a valid url' do
+      user.homepage = 'http://www.example.com'
+
+      expect(user).to be_valid
     end
 
-    it "allows a valid url" do
-      @user.homepage = "http://www.example.com"
-      expect(@user).to be_valid
+    it 'does not allow invalid url' do
+      user.homepage = 'random'
+
+      expect(user).not_to be_valid
     end
 
-    it "does not allow invalid url" do
-      @user.homepage = "random"
-      expect(@user).not_to be_valid
-    end
+    it 'allows a url with an underscore' do
+      user.homepage = 'http://foo_bar.com'
 
-    it "allows a url with an underscore" do
-      @user.homepage = "http://foo_bar.com"
-      expect(@user).to be_valid
-    end
-  end
-
-  context "with ActiveRecord" do
-    before do
-      @user = UserWithAr.new
-    end
-
-    it "does not allow invalid url" do
-      @user.homepage = "random"
-      expect(@user).not_to be_valid
+      expect(user).to be_valid
     end
   end
 
-  context "with ActiveRecord and legacy syntax" do
-    before do
-      @user = UserWithArLegacy.new
-    end
+  context 'with ActiveRecord' do
+    let!(:user) { UserWithAr.new }
 
-    it "does not allow invalid url" do
-      @user.homepage = "random"
-      expect(@user).not_to be_valid
-    end
-  end
+    it 'does not allow invalid url' do
+      user.homepage = 'random'
 
-  context "with regular validator and custom scheme" do
-    before do
-      @user = UserWithCustomScheme.new
-    end
-
-    it "allows alternative URI schemes" do
-      @user.homepage = "ftp://ftp.example.com"
-      expect(@user).to be_valid
+      expect(user).not_to be_valid
     end
   end
 
-  context "with custom message" do
-    before do
-      @user = UserWithCustomMessage.new
-    end
+  context 'with ActiveRecord and legacy syntax' do
+    let!(:user) { UserWithArLegacy.new }
 
-    it "uses custom message" do
-      @user.homepage = "invalid"
-      @user.valid?
-      expect(@user.errors[:homepage]).to eq(["wrong"])
+    it 'does not allow invalid url' do
+      user.homepage = 'random'
+
+      expect(user).not_to be_valid
+    end
+  end
+
+  context 'with regular validator and custom scheme' do
+    let!(:user) { UserWithCustomScheme.new }
+
+    it 'allows alternative URI schemes' do
+      user.homepage = 'ftp://ftp.example.com'
+
+      expect(user).to be_valid
+    end
+  end
+
+  context 'with custom message' do
+    let!(:user) { UserWithCustomMessage.new }
+
+    it 'uses custom message' do
+      user.homepage = 'invalid'
+      user.valid?
+
+      expect(user.errors[:homepage]).to eq(['wrong'])
     end
   end
 end


### PR DESCRIPTION
This PR is a formatting PR. Hopefully, this is easier to scan.

It uses two RSpec features:

- [disable_monkey_patching](https://www.rubydoc.info/github/rspec/rspec-core/RSpec%2FCore%2FConfiguration:disable_monkey_patching!) setting
- `let!`, which is a an alternative to instance variables in `before` blocks

TODO:

- [ ] Harmonize ' into " for these files
- [ ] Avoid extra spaces