### PR TITLE
removed period("。") from local/ja.yaml like any other language.

### DIFF
--- a/lib/locale/ja.yml
+++ b/lib/locale/ja.yml
@@ -1,4 +1,4 @@
 ja:
   errors:
     messages:
-      url: は不正なURLです。
+      url: は不正なURLです

--- a/spec/validate_url_spec.rb
+++ b/spec/validate_url_spec.rb
@@ -95,7 +95,7 @@ describe "URL validation" do
         I18n.locale = :ja
         @user.homepage = "黒麦茶"
         @user.valid?
-        expect(@user.errors[:homepage]).to eq(["は不正なURLです。"])
+        expect(@user.errors[:homepage]).to eq(["は不正なURLです"])
       end
     end
   end


### PR DESCRIPTION
period(".") ​​is "。" In Japanese.

In other languages, error messages are set without period, but in Japanese, it is assigned.
https://github.com/perfectline/validates_url/blob/master/lib/locale/en.yml#L4

``` yaml
en:
  errors:
    messages:
      url: is not a valid URL
```

So I removed "。" from ja.yaml

ref: https://github.com/perfectline/validates_url/pull/28