### PR TITLE
Pass options as keywords in errors.add

### DIFF
--- a/lib/validate_url.rb
+++ b/lib/validate_url.rb
@@ -33,7 +33,7 @@ module ActiveModel
             record.errors.add(attribute, options.fetch(:message), value: value)
           end
         rescue URI::InvalidURIError
-          record.errors.add(attribute, :url, filtered_options(value))
+          record.errors.add(attribute, :url, **filtered_options(value))
         end
       end
 


### PR DESCRIPTION
Prevent this warning on Ruby 2.7:

```
/tmp/bundle/ruby/2.7.0/gems/validate_url-1.0.11/lib/validate_url.rb:36: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/tmp/bundle/ruby/2.7.0/bundler/gems/rails-9817d74f3be7/activemodel/lib/active_model/errors.rb:395: warning: The called method `add' is defined here
```
