### PR TITLE
Fix for invalid mailto urls

### DIFF
--- a/lib/validate_url.rb
+++ b/lib/validate_url.rb
@@ -62,7 +62,7 @@ module ActiveModel
         unless valid_raw_url && valid_scheme && valid_no_local && valid_suffix
           record.errors.add(attribute, options.fetch(:message), value: value)
         end
-      rescue URI::InvalidURIError
+      rescue URI::InvalidURIError, URI::InvalidComponentError
         record.errors.add(attribute, :url, **filtered_options(value))
       end
     end

--- a/spec/validate_url_spec.rb
+++ b/spec/validate_url_spec.rb
@@ -111,6 +111,12 @@ RSpec.describe 'URL validation' do
         expect(user.errors[:homepage]).to eq(['は不正なURLです'])
       end
     end
+
+    it 'does not allow a mailto url without local-part' do
+      user.homepage = 'mailto:@bar.com'
+
+      expect(user).not_to be_valid
+    end
   end
 
   context 'with allow nil' do


### PR DESCRIPTION
A user submitted an invalid mailto url with a missing local-part.
It ended up with the following error:
```
URI::InvalidComponentError
unrecognised opaque part for mailtoURL: @example.com
```