### PR TITLE
Add a changelog describing the two most recent releases of the gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# v1.0.15 (May 13, 2022)
+
+* Add Dutch and Portuguese error message translations
+
+# v1.0.14 (May 13, 2022)
+
+* Support validating arrays of URLs with the `accept_array: true` option
+* Stop raising an error when validating a `mailto:` URL without a local-part (the portion before the `@` sign)
+* Remove periods from the ends of Italian and Polish error message translations

--- a/README.md
+++ b/README.md
@@ -96,12 +96,17 @@ redistributed under the terms specified in the LICENSE file.
 
 ## How to push a new version
 
+1. Bump the version number automatically:
+
 ```sh
 rake version:bump:patch
 rake gemspec
 ```
 
-Manually update `validate_url.gemspec` to remove incorrect strings.
+2. Manually update `validate_url.gemspec` to remove incorrect strings
+3. Update `CHANGELOG.md` to describe what is changing in the new version
+4. Commit and push the updated version information, gemspec and changelog to GitHub
+5. Build and push the gem to RubyGems
 
 ```sh
 gem build validate_url.gemspec

--- a/validate_url.gemspec
+++ b/validate_url.gemspec
@@ -49,6 +49,10 @@ Gem::Specification.new do |s|
   s.rubygems_version = "3.0.8".freeze
   s.summary = "Library for validating urls in Rails.".freeze
 
+  s.metadata = {
+    "changelog_uri".freeze => "https://github.com/perfectline/validates_url/blob/master/CHANGELOG.md".freeze
+  }
+
   if s.respond_to? :specification_version then
     s.specification_version = 4
 


### PR DESCRIPTION
This adds a changelog with what changed in the most recent two versions released today (Friday 13th May 2022).

This makes it easier for users to see what has changed and make decisions about how and when to upgrade, and of course to learn about new features.

This PR also points to that changelog from the gemspec metadata (so tools like Dependabot can pick it up) and adds the changelog to the release instructions.