### PR TITLE
Update CI so it runs correctly for Ruby 2.3 - Ruby head

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,46 +1,27 @@
 name: Run tests
 
-on:
-  pull_request:
-  push:
-    branches:
-      - '**'
-    tags-ignore:
-      - 'v*'
+on: [push, pull_request]
 
 jobs:
   test:
-    name: "Run tests"
+    name: "Run tests for ${{matrix.ruby}}"
     if: "! contains(toJSON(github.event.commits.latest.message), '[skip ci]')"
     runs-on: ubuntu-latest
+
     strategy:
       fail-fast: false
       matrix:
-        include:
-          # - ruby: 3.0 # Not working due to nokogiri
-          - ruby: 2.7
-          - ruby: 2.6
-          - ruby: 2.5
-          # - ruby: 2.4 # Not working due to nokogiri
-          # - ruby: 2.3 # Not working due to nokogiri
-    container:
-      image: ruby:${{ matrix.ruby }}
-      env:
-        CI: true
+        ruby: ["2.3", "2.4", "2.5", "2.6", "2.7", "3.0", "3.1", "3.2", ruby-head]
+
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: bundle-${{ matrix.ruby }}-${{ hashFiles('**/*.gemspec') }}-${{ hashFiles('**/Gemfile') }}
-          restore-keys: |
-            bundle-${{ matrix.ruby }}-${{ hashFiles('**/*.gemspec') }}-${{ hashFiles('**/Gemfile') }}
-            bundle-${{ matrix.ruby }}-
-      - name: Install Bundler version from Gemfile
-        run: gem install bundler -v $(grep -A 1 "BUNDLED WITH" Gemfile.lock | tail -n 1)
-      - name: Bundle install
-        run: |
-          bundle config path vendor/bundle
-          bundle install
-      - name: Run RSpec
-        run: bundle exec rspec
+    - uses: actions/checkout@v3
+    - name: Remove Gemfile.lock
+      run: |
+        rm Gemfile.lock
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true # 'bundle install' and cache gems
+        ruby-version: ${{ matrix.ruby }}
+    - name: Run tests
+      run: bundle exec rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,110 +1,58 @@
 PATH
   remote: .
   specs:
-    validate_url (1.0.13)
+    validate_url (1.0.15)
       activemodel (>= 3.0.0)
       public_suffix
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.2.4.5)
-      activesupport (= 5.2.4.5)
-    activerecord (5.2.4.5)
-      activemodel (= 5.2.4.5)
-      activesupport (= 5.2.4.5)
-      arel (>= 9.0)
-    activesupport (5.2.4.5)
+    activemodel (7.0.5)
+      activesupport (= 7.0.5)
+    activerecord (7.0.5)
+      activemodel (= 7.0.5)
+      activesupport (= 7.0.5)
+    activesupport (7.0.5)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-    addressable (2.4.0)
-    arel (9.0.0)
-    builder (3.2.3)
-    concurrent-ruby (1.1.8)
-    descendants_tracker (0.0.4)
-      thread_safe (~> 0.3, >= 0.3.1)
-    diff-lcs (1.3)
-    faraday (0.9.2)
-      multipart-post (>= 1.2, < 3)
-    git (1.5.0)
-    github_api (0.16.0)
-      addressable (~> 2.4.0)
-      descendants_tracker (~> 0.0.4)
-      faraday (~> 0.8, < 0.10)
-      hashie (>= 3.4)
-      mime-types (>= 1.16, < 3.0)
-      oauth2 (~> 1.0)
-    hashie (3.6.0)
-    highline (2.0.0)
-    i18n (1.8.10)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    concurrent-ruby (1.2.2)
+    diff-lcs (1.5.0)
+    i18n (1.13.0)
       concurrent-ruby (~> 1.0)
-    jeweler (2.3.9)
-      builder
-      bundler
-      git (>= 1.2.5)
-      github_api (~> 0.16.0)
-      highline (>= 1.6.15)
-      nokogiri (>= 1.5.10)
-      psych
-      rake
-      rdoc
-      semver2
-    jwt (2.1.0)
-    mime-types (2.99.3)
-    mini_portile2 (2.8.0)
-    minitest (5.14.4)
-    multi_json (1.13.1)
-    multi_xml (0.6.0)
-    multipart-post (2.0.0)
-    nokogiri (1.13.6)
-      mini_portile2 (~> 2.8.0)
-      racc (~> 1.4)
-    oauth2 (1.4.1)
-      faraday (>= 0.8, < 0.16.0)
-      jwt (>= 1.0, < 3.0)
-      multi_json (~> 1.3)
-      multi_xml (~> 0.5)
-      rack (>= 1.2, < 3)
-    psych (4.0.3)
-      stringio
-    public_suffix (4.0.6)
-    racc (1.6.0)
-    rack (2.2.3)
-    rake (13.0.1)
-    rdoc (6.4.0)
-      psych (>= 4.0.0)
-    rspec (3.8.0)
-      rspec-core (~> 3.8.0)
-      rspec-expectations (~> 3.8.0)
-      rspec-mocks (~> 3.8.0)
-    rspec-core (3.8.0)
-      rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.2)
+    minitest (5.18.0)
+    public_suffix (5.0.1)
+    rake (13.0.6)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-mocks (3.8.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.5)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-support (3.8.0)
-    semver2 (3.4.2)
-    sqlite3 (1.3.13)
-    stringio (3.0.2)
-    thread_safe (0.3.6)
-    tzinfo (1.2.9)
-      thread_safe (~> 0.1)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.0)
+    sqlite3 (1.6.3-x86_64-darwin)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
 
 PLATFORMS
-  ruby
+  x86_64-darwin-21
+  x86_64-darwin-22
 
 DEPENDENCIES
-  activerecord
+  activerecord (>= 3.0.0)
   diff-lcs (>= 1.1.2)
-  jeweler
-  rspec
+  rake (>= 11.0)
+  rspec (~> 3)
   sqlite3
   validate_url!
 
 BUNDLED WITH
-   1.17.2
+   2.4.13

--- a/Rakefile
+++ b/Rakefile
@@ -2,25 +2,9 @@ require 'rake'
 require 'rdoc/task'
 require 'rake/clean'
 require 'rspec/core/rake_task'
-require 'jeweler'
 
 desc 'Default: run unit tests.'
 task default: :test
-
-Jeweler::Tasks.new do |jewel|
-  jewel.name            = 'validate_url'
-  jewel.summary         = 'Library for validating urls in Rails.'
-  jewel.email           = ['tanel.suurhans@perfectline.co', 'tarmo.lehtpuu@perfectline.co', 'vladimir.krylov@perfectline.co']
-  jewel.homepage        = 'http://github.com/perfectline/validates_url/tree/master'
-  jewel.description     = 'Library for validating urls in Rails.'
-  jewel.authors         = ["Tanel Suurhans", "Tarmo Lehtpuu", "Vladimir Krylov"]
-  jewel.files           = FileList["lib/**/*.rb", "lib/locale/*.yml", "*.rb", "LICENSE.md", "README.md"]
-
-  jewel.add_dependency 'activemodel', '>= 3.0.0'
-  jewel.add_dependency 'public_suffix'
-  jewel.add_development_dependency 'rspec'
-  jewel.add_development_dependency 'diff-lcs', '>= 1.1.2'
-end
 
 desc 'Generate documentation plugin.'
 RDoc::Task.new(:rdoc) do |rdoc|

--- a/lib/validate_url.rb
+++ b/lib/validate_url.rb
@@ -55,7 +55,7 @@ module ActiveModel
         scheme = uri && uri.scheme
 
         valid_raw_url = scheme && value =~ /\A#{URI::regexp([scheme])}\z/
-        valid_scheme = host && scheme && schemes.include?(scheme)
+        valid_scheme = host && !host.empty? && scheme && schemes.include?(scheme)
         valid_no_local = !options.fetch(:no_local) || (host && host.include?('.'))
         valid_suffix = !options.fetch(:public_suffix) || (host && PublicSuffix.valid?(host, :default_rule => nil))
 

--- a/validate_url.gemspec
+++ b/validate_url.gemspec
@@ -48,38 +48,18 @@ Gem::Specification.new do |s|
   s.homepage = "http://github.com/perfectline/validates_url/tree/master".freeze
   s.rubygems_version = "3.0.8".freeze
   s.summary = "Library for validating urls in Rails.".freeze
+  s.specification_version = 4
 
   s.metadata = {
     "changelog_uri".freeze => "https://github.com/perfectline/validates_url/blob/master/CHANGELOG.md".freeze
   }
 
-  if s.respond_to? :specification_version then
-    s.specification_version = 4
+  s.add_dependency("activemodel", ">= 3.0.0")
+  s.add_dependency("public_suffix", ">= 0")
 
-    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_development_dependency(%q<jeweler>.freeze, [">= 0"])
-      s.add_development_dependency(%q<sqlite3>.freeze, [">= 0"])
-      s.add_development_dependency(%q<activerecord>.freeze, [">= 0"])
-      s.add_development_dependency(%q<rspec>.freeze, [">= 0"])
-      s.add_development_dependency(%q<diff-lcs>.freeze, [">= 1.1.2"])
-      s.add_runtime_dependency(%q<activemodel>.freeze, [">= 3.0.0"])
-      s.add_runtime_dependency(%q<public_suffix>.freeze, [">= 0"])
-    else
-      s.add_dependency(%q<jeweler>.freeze, [">= 0"])
-      s.add_dependency(%q<sqlite3>.freeze, [">= 0"])
-      s.add_dependency(%q<activerecord>.freeze, [">= 0"])
-      s.add_dependency(%q<rspec>.freeze, [">= 0"])
-      s.add_dependency(%q<diff-lcs>.freeze, [">= 1.1.2"])
-      s.add_dependency(%q<activemodel>.freeze, [">= 3.0.0"])
-      s.add_dependency(%q<public_suffix>.freeze, [">= 0"])
-    end
-  else
-    s.add_dependency(%q<jeweler>.freeze, [">= 0"])
-    s.add_dependency(%q<sqlite3>.freeze, [">= 0"])
-    s.add_dependency(%q<activerecord>.freeze, [">= 0"])
-    s.add_dependency(%q<rspec>.freeze, [">= 0"])
-    s.add_dependency(%q<diff-lcs>.freeze, [">= 1.1.2"])
-    s.add_dependency(%q<activemodel>.freeze, [">= 3.0.0"])
-    s.add_dependency(%q<public_suffix>.freeze, [">= 0"])
-  end
+  s.add_development_dependency("activerecord", ">= 3.0.0")
+  s.add_development_dependency("diff-lcs", ">= 1.1.2")
+  s.add_development_dependency("rake", ">= 11.0")
+  s.add_development_dependency("rspec", "~> 3")
+  s.add_development_dependency("sqlite3", ">= 0")
 end


### PR DESCRIPTION
This PR required some modernization of the gemspec, changes to the CI file, and a minor code change.  Everything runs green on my fork.

Also updates checkout action to v3, allowing it to run (v2 and earlier no longer run properly)