### PR TITLE
Add license info to jeweler task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,6 +14,7 @@ Jeweler::Tasks.new do |jewel|
   jewel.homepage        = 'http://github.com/perfectline/validates_url/tree/master'
   jewel.description     = 'Library for validating urls in Rails.'
   jewel.authors         = ["Tanel Suurhans", "Tarmo Lehtpuu", "Vladimir Krylov"]
+  jewel.license         = 'MIT'
   jewel.files           = FileList["lib/**/*.rb", "lib/locale/*.yml", "*.rb", "LICENSE.md", "README.md"]
 
   jewel.add_dependency 'activemodel', '>= 3.0.0'

--- a/validate_url.gemspec
+++ b/validate_url.gemspec
@@ -6,12 +6,12 @@
 
 Gem::Specification.new do |s|
   s.name = "validate_url".freeze
-  s.version = "1.0.15".freeze
+  s.version = "1.0.15"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib".freeze]
   s.authors = ["Tanel Suurhans".freeze, "Tarmo Lehtpuu".freeze, "Vladimir Krylov".freeze]
-  s.date = "2025-03-17"
+  s.date = "2022-05-13"
   s.description = "Library for validating urls in Rails.".freeze
   s.email = ["tanel.suurhans@perfectline.co".freeze, "tarmo.lehtpuu@perfectline.co".freeze, "vladimir.krylov@perfectline.co".freeze]
   s.extra_rdoc_files = [
@@ -28,7 +28,6 @@ Gem::Specification.new do |s|
     "lib/locale/en.yml",
     "lib/locale/es.yml",
     "lib/locale/fr.yml",
-    "lib/locale/gd.yml",
     "lib/locale/it.yml",
     "lib/locale/ja.yml",
     "lib/locale/km.yml",
@@ -47,21 +46,41 @@ Gem::Specification.new do |s|
     "lib/validate_url/rspec_matcher.rb"
   ]
   s.homepage = "http://github.com/perfectline/validates_url/tree/master".freeze
-  s.licenses = ["MIT".freeze]
-  s.rubygems_version = "3.4.22".freeze
+  s.rubygems_version = "3.0.8".freeze
   s.summary = "Library for validating urls in Rails.".freeze
+  s.licences = ["MIT".freeze]
 
-  s.specification_version = 4
+  s.metadata = {
+    "changelog_uri".freeze => "https://github.com/perfectline/validates_url/blob/master/CHANGELOG.md".freeze
+  }
 
-  s.add_runtime_dependency(%q<validate_url>.freeze, [">= 0".freeze])
-  s.add_development_dependency(%q<jeweler>.freeze, [">= 0".freeze])
-  s.add_development_dependency(%q<sqlite3>.freeze, [">= 0".freeze])
-  s.add_development_dependency(%q<activerecord>.freeze, [">= 0".freeze])
-  s.add_development_dependency(%q<rspec>.freeze, [">= 0".freeze])
-  s.add_development_dependency(%q<diff-lcs>.freeze, [">= 1.1.2".freeze])
-  s.add_runtime_dependency(%q<activemodel>.freeze, [">= 3.0.0".freeze])
-  s.add_runtime_dependency(%q<public_suffix>.freeze, [">= 0".freeze])
-  s.add_development_dependency(%q<rspec>.freeze, [">= 0".freeze])
-  s.add_development_dependency(%q<diff-lcs>.freeze, [">= 1.1.2".freeze])
+  if s.respond_to? :specification_version then
+    s.specification_version = 4
+
+    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
+      s.add_development_dependency(%q<jeweler>.freeze, [">= 0"])
+      s.add_development_dependency(%q<sqlite3>.freeze, [">= 0"])
+      s.add_development_dependency(%q<activerecord>.freeze, [">= 0"])
+      s.add_development_dependency(%q<rspec>.freeze, [">= 0"])
+      s.add_development_dependency(%q<diff-lcs>.freeze, [">= 1.1.2"])
+      s.add_runtime_dependency(%q<activemodel>.freeze, [">= 3.0.0"])
+      s.add_runtime_dependency(%q<public_suffix>.freeze, [">= 0"])
+    else
+      s.add_dependency(%q<jeweler>.freeze, [">= 0"])
+      s.add_dependency(%q<sqlite3>.freeze, [">= 0"])
+      s.add_dependency(%q<activerecord>.freeze, [">= 0"])
+      s.add_dependency(%q<rspec>.freeze, [">= 0"])
+      s.add_dependency(%q<diff-lcs>.freeze, [">= 1.1.2"])
+      s.add_dependency(%q<activemodel>.freeze, [">= 3.0.0"])
+      s.add_dependency(%q<public_suffix>.freeze, [">= 0"])
+    end
+  else
+    s.add_dependency(%q<jeweler>.freeze, [">= 0"])
+    s.add_dependency(%q<sqlite3>.freeze, [">= 0"])
+    s.add_dependency(%q<activerecord>.freeze, [">= 0"])
+    s.add_dependency(%q<rspec>.freeze, [">= 0"])
+    s.add_dependency(%q<diff-lcs>.freeze, [">= 1.1.2"])
+    s.add_dependency(%q<activemodel>.freeze, [">= 3.0.0"])
+    s.add_dependency(%q<public_suffix>.freeze, [">= 0"])
+  end
 end
-

--- a/validate_url.gemspec
+++ b/validate_url.gemspec
@@ -48,7 +48,6 @@ Gem::Specification.new do |s|
   s.homepage = "http://github.com/perfectline/validates_url/tree/master".freeze
   s.rubygems_version = "3.0.8".freeze
   s.summary = "Library for validating urls in Rails.".freeze
-  s.license = "MIT"
 
   s.metadata = {
     "changelog_uri".freeze => "https://github.com/perfectline/validates_url/blob/master/CHANGELOG.md".freeze

--- a/validate_url.gemspec
+++ b/validate_url.gemspec
@@ -6,12 +6,12 @@
 
 Gem::Specification.new do |s|
   s.name = "validate_url".freeze
-  s.version = "1.0.15"
+  s.version = "1.0.15".freeze
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib".freeze]
   s.authors = ["Tanel Suurhans".freeze, "Tarmo Lehtpuu".freeze, "Vladimir Krylov".freeze]
-  s.date = "2022-05-13"
+  s.date = "2025-03-17"
   s.description = "Library for validating urls in Rails.".freeze
   s.email = ["tanel.suurhans@perfectline.co".freeze, "tarmo.lehtpuu@perfectline.co".freeze, "vladimir.krylov@perfectline.co".freeze]
   s.extra_rdoc_files = [
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
     "lib/locale/en.yml",
     "lib/locale/es.yml",
     "lib/locale/fr.yml",
+    "lib/locale/gd.yml",
     "lib/locale/it.yml",
     "lib/locale/ja.yml",
     "lib/locale/km.yml",
@@ -46,40 +47,21 @@ Gem::Specification.new do |s|
     "lib/validate_url/rspec_matcher.rb"
   ]
   s.homepage = "http://github.com/perfectline/validates_url/tree/master".freeze
-  s.rubygems_version = "3.0.8".freeze
+  s.licenses = ["MIT".freeze]
+  s.rubygems_version = "3.4.22".freeze
   s.summary = "Library for validating urls in Rails.".freeze
 
-  s.metadata = {
-    "changelog_uri".freeze => "https://github.com/perfectline/validates_url/blob/master/CHANGELOG.md".freeze
-  }
+  s.specification_version = 4
 
-  if s.respond_to? :specification_version then
-    s.specification_version = 4
-
-    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_development_dependency(%q<jeweler>.freeze, [">= 0"])
-      s.add_development_dependency(%q<sqlite3>.freeze, [">= 0"])
-      s.add_development_dependency(%q<activerecord>.freeze, [">= 0"])
-      s.add_development_dependency(%q<rspec>.freeze, [">= 0"])
-      s.add_development_dependency(%q<diff-lcs>.freeze, [">= 1.1.2"])
-      s.add_runtime_dependency(%q<activemodel>.freeze, [">= 3.0.0"])
-      s.add_runtime_dependency(%q<public_suffix>.freeze, [">= 0"])
-    else
-      s.add_dependency(%q<jeweler>.freeze, [">= 0"])
-      s.add_dependency(%q<sqlite3>.freeze, [">= 0"])
-      s.add_dependency(%q<activerecord>.freeze, [">= 0"])
-      s.add_dependency(%q<rspec>.freeze, [">= 0"])
-      s.add_dependency(%q<diff-lcs>.freeze, [">= 1.1.2"])
-      s.add_dependency(%q<activemodel>.freeze, [">= 3.0.0"])
-      s.add_dependency(%q<public_suffix>.freeze, [">= 0"])
-    end
-  else
-    s.add_dependency(%q<jeweler>.freeze, [">= 0"])
-    s.add_dependency(%q<sqlite3>.freeze, [">= 0"])
-    s.add_dependency(%q<activerecord>.freeze, [">= 0"])
-    s.add_dependency(%q<rspec>.freeze, [">= 0"])
-    s.add_dependency(%q<diff-lcs>.freeze, [">= 1.1.2"])
-    s.add_dependency(%q<activemodel>.freeze, [">= 3.0.0"])
-    s.add_dependency(%q<public_suffix>.freeze, [">= 0"])
-  end
+  s.add_runtime_dependency(%q<validate_url>.freeze, [">= 0".freeze])
+  s.add_development_dependency(%q<jeweler>.freeze, [">= 0".freeze])
+  s.add_development_dependency(%q<sqlite3>.freeze, [">= 0".freeze])
+  s.add_development_dependency(%q<activerecord>.freeze, [">= 0".freeze])
+  s.add_development_dependency(%q<rspec>.freeze, [">= 0".freeze])
+  s.add_development_dependency(%q<diff-lcs>.freeze, [">= 1.1.2".freeze])
+  s.add_runtime_dependency(%q<activemodel>.freeze, [">= 3.0.0".freeze])
+  s.add_runtime_dependency(%q<public_suffix>.freeze, [">= 0".freeze])
+  s.add_development_dependency(%q<rspec>.freeze, [">= 0".freeze])
+  s.add_development_dependency(%q<diff-lcs>.freeze, [">= 1.1.2".freeze])
 end
+


### PR DESCRIPTION
It looks like the `gemspec` file is out of sync with what the `Jeweler` rake task produces. For my concern, I only care about the `licenses`, so I only added that part of what the raketask produced. However, it seems like changes were made to `gemspec` file that are not reflected by the `Jeweler` raketask.